### PR TITLE
Add new OpenAPI schema for Natiq API and refactor ayahs and mushafs 

### DIFF
--- a/Schema8.yaml
+++ b/Schema8.yaml
@@ -97,243 +97,6 @@ paths:
           description: User registered successfully, returns user data and token.
         '400':
           description: Validation error.
-  /ayah-translations/:
-    get:
-      operationId: ayah_translations_list
-      description: |-
-        ViewSet for AyahTranslation objects (translations of individual Ayahs).
-        Allows filtering by translation or ayah, and supports upsert on create.
-      summary: List all Ayah Translations
-      parameters:
-      - in: query
-        name: ayah_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Ayah UUID
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
-      - name: page
-        required: false
-        in: query
-        description: A page number within the paginated result set.
-        schema:
-          type: integer
-      - name: page_size
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: search
-        required: false
-        in: query
-        description: A search term.
-        schema:
-          type: string
-      - in: query
-        name: translation_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Translation UUID
-      tags:
-      - ayah-translations
-      security:
-      - knoxApiToken: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedAyahTranslationList'
-          description: ''
-    post:
-      operationId: ayah_translations_create
-      description: |-
-        ViewSet for AyahTranslation objects (translations of individual Ayahs).
-        Allows filtering by translation or ayah, and supports upsert on create.
-      summary: Create a new Ayah Translation record
-      parameters:
-      - in: query
-        name: ayah_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Ayah UUID
-      - in: query
-        name: translation_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Translation UUID
-      tags:
-      - ayah-translations
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AyahTranslation'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AyahTranslation'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AyahTranslation'
-        required: true
-      security:
-      - knoxApiToken: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AyahTranslation'
-          description: ''
-  /ayah-translations/{uuid}/:
-    get:
-      operationId: ayah_translations_retrieve
-      description: |-
-        ViewSet for AyahTranslation objects (translations of individual Ayahs).
-        Allows filtering by translation or ayah, and supports upsert on create.
-      summary: Retrieve a specific Ayah Translation by UUID
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
-      tags:
-      - ayah-translations
-      security:
-      - knoxApiToken: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AyahTranslation'
-          description: ''
-    put:
-      operationId: ayah_translations_update
-      description: |-
-        ViewSet for AyahTranslation objects (translations of individual Ayahs).
-        Allows filtering by translation or ayah, and supports upsert on create.
-      summary: Update an existing Ayah Translation record
-      parameters:
-      - in: query
-        name: ayah_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Ayah UUID
-      - in: query
-        name: translation_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Translation UUID
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
-      tags:
-      - ayah-translations
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AyahTranslation'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/AyahTranslation'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/AyahTranslation'
-        required: true
-      security:
-      - knoxApiToken: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AyahTranslation'
-          description: ''
-    patch:
-      operationId: ayah_translations_partial_update
-      description: |-
-        ViewSet for AyahTranslation objects (translations of individual Ayahs).
-        Allows filtering by translation or ayah, and supports upsert on create.
-      summary: Partially update an Ayah Translation record
-      parameters:
-      - in: query
-        name: ayah_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Ayah UUID
-      - in: query
-        name: translation_uuid
-        schema:
-          type: string
-          format: uuid
-        description: Translation UUID
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
-      tags:
-      - ayah-translations
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PatchedAyahTranslation'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/PatchedAyahTranslation'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/PatchedAyahTranslation'
-      security:
-      - knoxApiToken: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AyahTranslation'
-          description: ''
-    delete:
-      operationId: ayah_translations_destroy
-      description: |-
-        ViewSet for AyahTranslation objects (translations of individual Ayahs).
-        Allows filtering by translation or ayah, and supports upsert on create.
-      summary: Delete an Ayah Translation record
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
-      tags:
-      - ayah-translations
-      security:
-      - knoxApiToken: []
-      responses:
-        '204':
-          description: No response body
   /ayahs/:
     get:
       operationId: ayahs_list
@@ -884,6 +647,7 @@ paths:
   /notifications/:
     get:
       operationId: notifications_list
+      summary: List all notifications
       parameters:
       - name: page
         required: false
@@ -910,6 +674,7 @@ paths:
           description: ''
     post:
       operationId: notifications_create
+      summary: Create a new notification
       tags:
       - notifications
       requestBody:
@@ -936,6 +701,7 @@ paths:
   /notifications/{id}/:
     get:
       operationId: notifications_retrieve
+      summary: Retrieve a specific notification by UUID
       parameters:
       - in: path
         name: id
@@ -956,6 +722,7 @@ paths:
           description: ''
     put:
       operationId: notifications_update
+      summary: Update an existing notification
       parameters:
       - in: path
         name: id
@@ -988,6 +755,7 @@ paths:
           description: ''
     patch:
       operationId: notifications_partial_update
+      summary: Partially update a notification
       parameters:
       - in: path
         name: id
@@ -1019,6 +787,7 @@ paths:
           description: ''
     delete:
       operationId: notifications_destroy
+      summary: Delete a notification
       parameters:
       - in: path
         name: id
@@ -1818,7 +1587,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedTranslationList'
+                $ref: '#/components/schemas/PaginatedTranslationListList'
           description: ''
     post:
       operationId: translations_create
@@ -1832,13 +1601,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/TranslationList'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/TranslationList'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/TranslationList'
         required: true
       security:
       - knoxApiToken: []
@@ -1847,7 +1616,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Translation'
+                $ref: '#/components/schemas/TranslationList'
           description: ''
   /translations/{uuid}/:
     get:
@@ -1857,6 +1626,12 @@ paths:
         Supports filtering by Mushaf and language, and restricts editing of published translations.
       summary: Retrieve a specific Translation by UUID
       parameters:
+      - in: query
+        name: surah_uuid
+        schema:
+          type: string
+          format: uuid
+        description: UUID of the Surah to filter ayahs_translations by.
       - in: path
         name: uuid
         schema:
@@ -1893,13 +1668,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/TranslationList'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/TranslationList'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/Translation'
+              $ref: '#/components/schemas/TranslationList'
         required: true
       security:
       - knoxApiToken: []
@@ -1908,7 +1683,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Translation'
+                $ref: '#/components/schemas/TranslationList'
           description: ''
     patch:
       operationId: translations_partial_update
@@ -1929,13 +1704,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedTranslation'
+              $ref: '#/components/schemas/PatchedTranslationList'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedTranslation'
+              $ref: '#/components/schemas/PatchedTranslationList'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedTranslation'
+              $ref: '#/components/schemas/PatchedTranslationList'
       security:
       - knoxApiToken: []
       responses:
@@ -1943,7 +1718,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Translation'
+                $ref: '#/components/schemas/TranslationList'
           description: ''
     delete:
       operationId: translations_destroy
@@ -1964,6 +1739,165 @@ paths:
       - knoxApiToken: []
       responses:
         '204':
+          description: No response body
+  /translations/{uuid}/ayah/{ayah_uuid}/:
+    post:
+      operationId: translations_ayah_create_2
+      description: Provide the ayah's UUID in the URL path and the translation's UUID
+        as the primary resource path. Body requires only `text` (and optional `bismillah`).
+        If an AyahTranslation already exists it will be updated, otherwise it will
+        be created.
+      summary: Create or update (upsert) a specific AyahTranslation
+      parameters:
+      - in: path
+        name: ayah_uuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - translations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+        required: true
+      security:
+      - knoxApiToken: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AyahTranslation'
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AyahTranslation'
+          description: ''
+    put:
+      operationId: translations_ayah_update
+      description: Provide the ayah's UUID in the URL path and the translation's UUID
+        as the primary resource path. Body requires only `text` (and optional `bismillah`).
+        If an AyahTranslation already exists it will be updated, otherwise it will
+        be created.
+      summary: Create or update (upsert) a specific AyahTranslation
+      parameters:
+      - in: path
+        name: ayah_uuid
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - translations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+        required: true
+      security:
+      - knoxApiToken: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AyahTranslation'
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AyahTranslation'
+          description: ''
+  /translations/ayah/:
+    get:
+      operationId: translations_ayah_retrieve
+      description: |-
+        List AyahTranslation instances filtered by `translation_uuid`, `ayah_uuid`, or `surah_uuid`.
+        Mirrors the functionality previously provided by the AyahTranslationViewSet list endpoint.
+      summary: List Ayah Translations related to Translations
+      parameters:
+      - in: query
+        name: ayah_uuid
+        schema:
+          type: string
+          format: uuid
+        description: Ayah UUID
+      - in: query
+        name: surah_uuid
+        schema:
+          type: string
+          format: uuid
+        description: Surah UUID
+      - in: query
+        name: translation_uuid
+        schema:
+          type: string
+          format: uuid
+        description: Translation UUID
+      tags:
+      - translations
+      security:
+      - knoxApiToken: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationList'
+          description: ''
+    post:
+      operationId: translations_ayah_create
+      description: |-
+        Create a new AyahTranslation or update it if it already exists (upsert behaviour).
+        Expects `translation_uuid`, `ayah_uuid`, and `text` in the payload (or corresponding query parameters).
+      summary: Create or update (upsert) an Ayah Translation
+      tags:
+      - translations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AyahTranslation'
+        required: true
+      security:
+      - knoxApiToken: []
+      responses:
+        '201':
           description: No response body
   /translations/import/:
     post:
@@ -1993,7 +1927,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Translation'
+                $ref: '#/components/schemas/TranslationList'
           description: ''
   /upload/:
     post:
@@ -2674,10 +2608,6 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Ayah'
-    PaginatedAyahTranslationList:
-      type: array
-      items:
-        $ref: '#/components/schemas/AyahTranslation'
     PaginatedMushafList:
       type: array
       items:
@@ -2694,10 +2624,10 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Surah'
-    PaginatedTranslationList:
+    PaginatedTranslationListList:
       type: array
       items:
-        $ref: '#/components/schemas/Translation'
+        $ref: '#/components/schemas/TranslationList'
     PaginatedWordList:
       type: array
       items:
@@ -2730,26 +2660,6 @@ components:
         surah:
           type: string
           readOnly: true
-    PatchedAyahTranslation:
-      type: object
-      properties:
-        uuid:
-          type: string
-          format: uuid
-          readOnly: true
-        translation_uuid:
-          type: string
-          format: uuid
-          writeOnly: true
-        ayah_uuid:
-          type: string
-          format: uuid
-          writeOnly: true
-        text:
-          type: string
-        bismillah:
-          type: string
-          nullable: true
     PatchedGroup:
       type: object
       properties:
@@ -2911,7 +2821,7 @@ components:
         number_of_ayahs:
           type: string
           readOnly: true
-    PatchedTranslation:
+    PatchedTranslationList:
       type: object
       properties:
         uuid:
@@ -3255,6 +3165,37 @@ components:
       - mushaf_uuid
       - translator_uuid
       - uuid
+    TranslationList:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        mushaf_uuid:
+          type: string
+          readOnly: true
+        translator_uuid:
+          type: string
+          readOnly: true
+        language:
+          type: string
+          maxLength: 5
+        release_date:
+          type: string
+          format: date
+          nullable: true
+        source:
+          type: string
+          nullable: true
+          maxLength: 300
+        status:
+          $ref: '#/components/schemas/Status115Enum'
+      required:
+      - language
+      - mushaf_uuid
+      - translator_uuid
+      - uuid
     UploadSubjectListResponse:
       type: object
       properties:
@@ -3325,3 +3266,31 @@ components:
       in: header
       name: Authorization
       description: Token-based authentication with required prefix "Token"
+tags:
+- name: auth
+  description: Authentication and authorization endpoints (login, logout, register,
+    token management)
+- name: profile
+  description: Endpoints for retrieving and updating the current user's profile
+- name: users
+  description: Admin-only endpoints to list, create, update and delete users
+- name: groups
+  description: Admin-only endpoints to manage permission groups
+- name: mushafs
+  description: Manage Quranic manuscripts / editions
+- name: surahs
+  description: Manage chapters of the Quran (Surahs)
+- name: ayahs
+  description: Manage verses of the Quran (Ayahs)
+- name: words
+  description: Manage words within Quranic verses
+- name: translations
+  description: Create, update and list Quran translations and their verse/ayah translations
+- name: recitations
+  description: Manage audio recitations of the Quran
+- name: phrases
+  description: Create and maintain phrases for the application
+- name: notifications
+  description: Endpoints related to user notifications
+- name: upload
+  description: Generic file-upload endpoints (JSON imports, subject uploads, etc.)

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ntq/sdk",
-    "version": "1.1.62",
+    "version": "1.1.63",
     "private": false,
     "author": "Natiq",
     "description": "Natiq Open API SDK",

--- a/typescript/src/modules/ayahs.ts
+++ b/typescript/src/modules/ayahs.ts
@@ -12,15 +12,6 @@ import {
     AyahsEditResponseData,
     AyahsPartialEditRequestData,
     AyahsPartialEditResponseData,
-    AyahsTranslationListRequestParams,
-    AyahsTranslationListResponseData,
-    AyahsTranslationViewResponseData,
-    AyahsTranslationAddRequestData,
-    AyahsTranslationAddResponseData,
-    AyahsTranslationEditRequestData,
-    AyahsTranslationEditResponseData,
-    AyahsTranslationPartialEditRequestData,
-    AyahsTranslationPartialEditResponseData,
 } from "../types/ayahs";
 
 export class ControllerAyahs extends BaseController {
@@ -75,59 +66,5 @@ export class ControllerAyahs extends BaseController {
         config?: RequestConfig
     ): Promise<AxiosResponse<DefaultResponseData>> {
         return this.axiosDelete(`/ayahs/${uuid}/`, config);
-    }
-
-    // ===== Ayahs Translation =====
-
-    /** GET /ayahs/translation/ */
-    async listTranslations(
-        config?: RequestConfig<AyahsTranslationListRequestParams>
-    ): Promise<AxiosResponse<AyahsTranslationListResponseData>> {
-        return this.axiosGet(`/ayahs/translation/`, config);
-    }
-
-    /** GET /ayahs/translation/{uuid}/ */
-    async viewTranslation(
-        uuid: string,
-        config?: RequestConfig
-    ): Promise<AxiosResponse<AyahsTranslationViewResponseData>> {
-        return this.axiosGet(`/ayahs/translation/${uuid}/`, config);
-    }
-
-    /** POST /ayahs/translation/ */
-    async addTranslation(
-        data: AyahsTranslationAddRequestData,
-        config?: RequestConfig
-    ): Promise<AxiosResponse<AyahsTranslationAddResponseData>> {
-        return this.axiosPost(`/ayahs/translation/`, data, config);
-    }
-
-    /** PUT /ayahs/translation/{uuid}/ */
-    async editTranslation(
-        uuid: string,
-        data: AyahsTranslationEditRequestData,
-        config?: RequestConfig
-    ): Promise<AxiosResponse<AyahsTranslationEditResponseData>> {
-        return this.axiosPut(`/ayahs/translation/${uuid}/`, data, config);
-    }
-
-    /** PATCH /ayahs/translation/{uuid}/ */
-    async partialEditTranslation(
-        data: AyahsTranslationPartialEditRequestData,
-        config?: RequestConfig
-    ): Promise<AxiosResponse<AyahsTranslationPartialEditResponseData>> {
-        return this.axiosPatch(
-            `/ayahs/translation/${data.ayah_uuid}/`,
-            data,
-            config
-        );
-    }
-
-    /** DELETE /ayahs/translation/{uuid}/ */
-    async deleteTranslation(
-        uuid: string,
-        config?: RequestConfig
-    ): Promise<AxiosResponse<DefaultResponseData>> {
-        return this.axiosDelete(`/ayahs/translation/${uuid}/`, config);
     }
 }

--- a/typescript/src/modules/mushafs.ts
+++ b/typescript/src/modules/mushafs.ts
@@ -11,6 +11,12 @@ import {
     MushafEditResponseData,
     MushafsPartialEditRequestData,
     MushafsPartialEditResponseData,
+    MushafImportRequestData,
+    MushafImportResponseData,
+    MushafAyahMapResponseData,
+    MushafAyahMapRequestParams,
+    MushafImportBreakersRequestParams,
+    MushafImportBreakersRequestData,
 } from "../types/mushafs";
 
 export class ControllerMushafs extends BaseController {
@@ -66,5 +72,54 @@ export class ControllerMushafs extends BaseController {
     ): Promise<AxiosResponse<DefaultResponseData>> {
         return await this.axiosDelete(`/mushafs/${uuid}/`, config);
     }
+
+    /** POST /mushafs/import/ */
+  async import (
+    data: MushafImportRequestData,
+    config?: RequestConfig
+  ): Promise<AxiosResponse<MushafImportResponseData>> {
+    const formData = new FormData();
+    formData.append("file", data.file);
+
+    const importConfig = {
+      ...config,
+      headers: {
+        ...(config?.headers || {}),
+        "Content-Type": "multipart/form-data",
+      },
+    };
+
+    return await this.axiosPost(`/mushafs/import/`, formData, importConfig);
+  }
+    /** POST /mushafs/import_breakers/{mushaf_uuid}/?type=page */
+    async importBreakers(
+        params: MushafImportBreakersRequestParams,
+        data: MushafImportBreakersRequestData,
+        config?: RequestConfig
+      ): Promise<AxiosResponse> {
+        const formData = new FormData();
+        formData.append("file", data.file);
+    
+        const query = params.type ? `?type=${params.type}` : "";
+        const url = `/mushafs/import_breakers/${params.mushaf_uuid}/${query}`;
+    
+        const importConfig = {
+          ...config,
+          headers: {
+            ...(config?.headers || {}),
+            "Content-Type": "multipart/form-data",
+          },
+        };
+    
+        return await this.axiosPost(url, formData, importConfig);
+      }
+    
+      /** GET /mushafs/map/{mushaf_uuid}/ */
+      async getAyahMap(
+        params: MushafAyahMapRequestParams,
+        config?: RequestConfig
+      ): Promise<AxiosResponse<MushafAyahMapResponseData>> {
+        return await this.axiosGet(`/mushafs/map/${params.mushaf_uuid}/`, config);
+      } 
 }
 

--- a/typescript/src/modules/translation.ts
+++ b/typescript/src/modules/translation.ts
@@ -13,6 +13,12 @@ import {
     TranslationsPartialEditRequestData,
     TranslationsPartialEditResponseData,
     TranslationsViewRequestParams,
+    AyahsTranslationListRequestParams,
+    AyahsTranslationListResponseData,
+    AyahsTranslationAddRequestData,
+    TranslationImportResponseData,
+    TranslationImportRequestData,
+    
 } from "../types/translations";
 
 export class ControllerTranslations extends BaseController {
@@ -68,4 +74,47 @@ export class ControllerTranslations extends BaseController {
     ): Promise<AxiosResponse<DefaultResponseData>> {
         return await this.axiosDelete(`/translations/${uuid}/`, config);
     }
+    // ===== Ayahs Translation =====
+
+    /** GET /ayahs/translation/ */
+    async listTranslations(
+        config?: RequestConfig<AyahsTranslationListRequestParams>
+    ): Promise<AxiosResponse<AyahsTranslationListResponseData>> {
+        return this.axiosGet(`/ayahs/translation/`, config);
+    }
+
+    /** POST /ayahs/translation/ */
+    async addTranslation(
+        data: AyahsTranslationAddRequestData,
+        config?: RequestConfig
+    ): Promise<AxiosResponse> {
+        return this.axiosPost(`/ayahs/translation/`, data, config);
+    }
+
+    /** DELETE /ayahs/translation/{uuid}/ */
+    async deleteTranslation(
+        uuid: string,
+        config?: RequestConfig
+    ): Promise<AxiosResponse<DefaultResponseData>> {
+        return this.axiosDelete(`/ayahs/translation/${uuid}/`, config);
+    }
+
+    /** POST /translations/import/ */
+    async import (
+        data: TranslationImportRequestData,
+        config?: RequestConfig
+    ): Promise<AxiosResponse<TranslationImportResponseData>> {
+        const formData = new FormData();
+        formData.append("file", data.file);
+
+        const importConfig = {
+            ...config,
+            headers: {
+                ...(config?.headers || {}),
+                "Content-Type": "multipart/form-data",
+            },
+        };
+        return this.axiosPost(`/translations/import/`, formData, importConfig);
+    }
 }
+

--- a/typescript/src/types/ayahs.ts
+++ b/typescript/src/types/ayahs.ts
@@ -42,36 +42,3 @@ export type AyahsEditResponseData = AyahsDefaultResponseData;
 // Ayahs PartialEdit
 export type AyahsPartialEditRequestData = Partial<AyahsDefaultRequestData>;
 export type AyahsPartialEditResponseData = AyahsDefaultResponseData;
-
-// Ayahs Translation
-interface AyahsTranslationDefaultRequestData {
-    translation_uuid?: string;
-    ayah_uuid?: string;
-    text: string;   
-    bismillah?: string;
-}
-interface AyahsTranslationDefaultResponseItem{
-    uuid: string;
-    text: string;   
-    bismillah?: string;
-}
- // Ayahs Translation List
-export interface AyahsTranslationListRequestParams extends FilterQueryParams {
-    ayah_uuid?: string;
-    translation_uuid?: string;
-}
-export type AyahsTranslationListResponseItem =  AyahsTranslationDefaultResponseItem;
-export type AyahsTranslationListResponseData = AyahsTranslationListResponseItem;
-
-// Ayahs Translation View
-export type AyahsTranslationViewResponseData = AyahsTranslationDefaultResponseItem; 
-export type AyahsTranslationAddRequestData = AyahsTranslationDefaultRequestData;
-export type AyahsTranslationAddResponseData = AyahsTranslationDefaultResponseItem;
-
-// Ayahs Translation Edit
-export type AyahsTranslationEditRequestData = AyahsTranslationDefaultRequestData;
-export type AyahsTranslationEditResponseData = AyahsTranslationDefaultResponseItem;
-
-// Ayahs Translation Partial Edit
-export type AyahsTranslationPartialEditRequestData = Partial<AyahsTranslationDefaultRequestData>;
-export type AyahsTranslationPartialEditResponseData = AyahsTranslationDefaultResponseItem;

--- a/typescript/src/types/mushafs.ts
+++ b/typescript/src/types/mushafs.ts
@@ -40,3 +40,31 @@ export interface MushafImportRequestData {
     file: File | Blob;
 }
 export type MushafImportResponseData = MushafsDefaultResponseData;
+
+// Mushaf Import Breakers
+export interface MushafImportBreakersRequestParams {
+    mushaf_uuid: string;
+    type?: "page" | "juz" | "hizb" | "ruku";
+  }
+  
+  export interface MushafImportBreakersRequestData {
+    file: File | Blob;
+  }
+  
+  
+  // Mushaf Ayah Map
+  export interface MushafAyahMapRequestParams {
+    mushaf_uuid: string;
+  }
+  
+  export interface MushafAyahMapItem {
+    uuid: string;
+    surah: number;
+    ayah: number;
+    juz: number ;
+    hizb: number ;
+    ruku: number ;
+    page: number ;
+  }
+  
+  export type MushafAyahMapResponseData = MushafAyahMapItem[];

--- a/typescript/src/types/translations.ts
+++ b/typescript/src/types/translations.ts
@@ -19,7 +19,7 @@ interface TranslationsDefaultResponseData {
 
 //Translations List
 export interface TranslationsListRequestParams extends FilterQueryParams {
-    language: string;
+    language?: string;
     mushaf_uuid: string;
 }
 export type TranslationsListResponseItem = TranslationsDefaultResponseData;
@@ -27,7 +27,7 @@ export type TranslationsListResponseData = TranslationsListResponseItem[];
 
 //Translations View
 export interface TranslationsViewRequestParams extends FilterQueryParams {
-    surah_uuid: string;
+    surah_uuid?: string; 
 }
 export interface TranslationsViewAyah {
     uuid: string;
@@ -52,3 +52,39 @@ export type TranslationsEditResponseData = TranslationsDefaultResponseData;
 export type TranslationsPartialEditRequestData = TranslationsDefaultRequestData;
 export type TranslationsPartialEditResponseData =
     Partial<TranslationsDefaultResponseData>;
+
+// AyahsTranslation 
+interface AyahsTranslationDefaultResponseData {
+    uuid: string;
+    mushaf_uuid: string;
+    translator_uuid: string;
+    language: string;
+    release_date?: string;
+    source?: string;
+    status?: Status;
+  }
+  
+  // AyahsTranslation List 
+  export interface AyahsTranslationListRequestParams {
+    translation_uuid?: string;
+    ayah_uuid?: string;
+    surah_uuid?: string;
+  }
+  
+  export type AyahsTranslationListResponseItem = AyahsTranslationDefaultResponseData;
+  export type AyahsTranslationListResponseData = AyahsTranslationListResponseItem[];
+  
+  // AyahsTranslation Add
+  export interface AyahsTranslationAddRequestData {
+    translation_uuid: string;
+    ayah_uuid: string;
+    text: string;
+    bismillah?: string;
+  }
+
+  // Translation Import
+  export interface TranslationImportRequestData {
+    file: File;
+  }
+  export type TranslationImportResponseData = TranslationsDefaultResponseData;
+


### PR DESCRIPTION
# API Changelog 1.0.0 vs. 1.0.0

## POST /mushafs/import_breakers/{mushaf_uuid}/
-  endpoint added


## GET /mushafs/map/{mushaf_uuid}/
-  endpoint added


## GET /recitations/
- :warning: the 'query' request parameter 'mushaf_uuid' became required


## GET /surahs/
- :warning: the 'query' request parameter 'mushaf' became required


## GET /translations/
- :warning: the 'query' request parameter 'mushaf_uuid' became required


